### PR TITLE
clog_editor_plugin.gd: fix in-editor errors on startup

### DIFF
--- a/addons/clog/clog_editor_plugin.gd
+++ b/addons/clog/clog_editor_plugin.gd
@@ -96,6 +96,7 @@ func _generate_colors_class_file():
 	file.flush()
 	file.close()
 	print("(re)generated clog_colors.gd")
+	for i in 5: await get_tree().process_frame
 	EditorInterface.get_resource_filesystem().scan()
 
 

--- a/addons/clog/clog_editor_plugin.gd
+++ b/addons/clog/clog_editor_plugin.gd
@@ -96,8 +96,6 @@ func _generate_colors_class_file():
 	file.flush()
 	file.close()
 	print("(re)generated clog_colors.gd")
-	for i in 5: await get_tree().process_frame
-	EditorInterface.get_resource_filesystem().scan()
 
 
 func _setup_timer():


### PR DESCRIPTION
When the editor starts up it may already run quick a file-system scan, and by scanning again immediately it allows conflicting access to the progress dialog. By giving it a few frames we can safely run the scan after generating the file.